### PR TITLE
Update drawio_base.ts

### DIFF
--- a/src/drawio_base.ts
+++ b/src/drawio_base.ts
@@ -345,7 +345,7 @@ export class GFDrawio {
 
   static isEncoded(data: string) {
     try {
-      GFDrawio.decode(data);
+      return Boolean(GFDrawio.decode(data).trim());
     } catch (error) {
       return false;
     }


### PR DESCRIPTION
Should provide a temporary fix for #395
What was happening was that the decode code was returns a " ", which is obviously a bad parse, then returning true, so the diagram.xml was being set to " ", breaking all the code.

A better fix might be possible, but this seems to do the job for now.